### PR TITLE
Add fix to JSON request body for Java demos

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,21 +1,20 @@
 plugins {
-    id 'java'
+  id 'java'
 }
 
 group 'org.example'
 version '1.0-SNAPSHOT'
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 dependencies {
-    implementation 'com.auth0:java-jwt:3.19.1'
-    implementation 'com.auth0:jwks-rsa:0.9.0'
-    implementation 'com.google.apis:google-api-services-oauth2:v1-rev20190313-1.30.3'
-    implementation 'com.google.api-client:google-api-client:2.0.0'
-    implementation 'com.google.auth:google-auth-library-oauth2-http:1.10.0'
-    implementation 'com.squareup.okhttp3:okhttp:4.3.1'
-    implementation 'javax.json:javax.json-api:1.1'
-    implementation 'org.glassfish:javax.json:1.1'
+  implementation 'com.auth0:java-jwt:3.19.1'
+  implementation 'com.auth0:jwks-rsa:0.9.0'
+  implementation 'com.google.apis:google-api-services-oauth2:v1-rev20190313-1.30.3'
+  implementation 'com.google.api-client:google-api-client:2.0.0'
+  implementation 'com.google.auth:google-auth-library-oauth2-http:1.10.0'
+  implementation 'com.google.guava:guava:r05'
+  implementation 'com.google.api-client:google-api-client:1.19.1'
 }

--- a/java/src/main/java/DemoEventticket.java
+++ b/java/src/main/java/DemoEventticket.java
@@ -21,12 +21,15 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.*;
 import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.collect.Lists;
 
-import java.io.FileInputStream;
+import java.io.*;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 // [END imports]
@@ -83,7 +86,7 @@ public class DemoEventticket {
     credentials.refresh();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory();
+    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory(new HttpCredentialsAdapter(credentials));
     // [END auth]
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -105,11 +108,13 @@ public class DemoEventticket {
       + "  \"reviewStatus\": \"underReview\""
       + "}", issuerId, classId);
 
-    HttpRequest classRequest = httpRequestFactory.buildPostRequest(
-        classUrl,
-        new JsonHttpContent(new GsonFactory(), classPayload));
-    classRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+    // Convert body to JSON
+    JsonParser classParser = GsonFactory.getDefaultInstance().createJsonParser(classPayload);
+    GenericJson classJson = classParser.parseAndClose(GenericJson.class);
+    HttpContent classBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), classJson);
+
+    // Create and send the request
+    HttpRequest classRequest = httpRequestFactory.buildPostRequest(classUrl, classBody);
     HttpResponse classResponse = classRequest.execute();
 
     System.out.println("class POST response:" + classResponse.parseAsString());
@@ -216,19 +221,20 @@ public class DemoEventticket {
       + "  ]"
       + "}", objectId, issuerId, classId);
 
+    // Create and send the request
     HttpRequest objectRequest = httpRequestFactory.buildGetRequest(objectUrl);
-    objectRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse objectResponse = objectRequest.execute();
 
     if (objectResponse.getStatusCode() == 404) {
       // Object does not yet exist
       // Send POST request to create it
-      objectRequest = httpRequestFactory.buildPostRequest(
-          objectUrl,
-          new JsonHttpContent(new GsonFactory(), objectPayload));
-      objectRequest.setHeaders(new HttpHeaders()
-          .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+      // Convert body to JSON
+      JsonParser objectParser = GsonFactory.getDefaultInstance().createJsonParser(objectPayload);
+      GenericJson objectJson = objectParser.parseAndClose(GenericJson.class);
+      HttpContent objectBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), objectJson);
+
+      // Create and send the request
+      objectRequest = httpRequestFactory.buildPostRequest(objectUrl, objectBody);
       objectResponse = objectRequest.execute();
     }
 
@@ -292,9 +298,7 @@ public class DemoEventticket {
 
     HttpRequest issuerRequest = httpRequestFactory.buildPostRequest(
         issuerUrl,
-        new JsonHttpContent(new GsonFactory(), issuerPayload));
-    issuerRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+        new JsonHttpContent(GsonFactory.getDefaultInstance(), issuerPayload));
     HttpResponse issuerResponse = issuerRequest.execute();
 
     System.out.println("issuer POST response: " + issuerResponse.parseAsString());
@@ -330,8 +334,6 @@ public class DemoEventticket {
     HttpRequest permissionsRequest = httpRequestFactory.buildPutRequest(
         permissionsUrl,
         new JsonHttpContent(new GsonFactory(), permissionsPayload));
-    permissionsRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse permissionsResponse = permissionsRequest.execute();
 
     System.out.println("permissions PUT response: " + permissionsResponse.parseAsString());

--- a/java/src/main/java/DemoFlight.java
+++ b/java/src/main/java/DemoFlight.java
@@ -21,12 +21,15 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.*;
 import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.collect.Lists;
 
-import java.io.FileInputStream;
+import java.io.*;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 // [END imports]
@@ -83,7 +86,7 @@ public class DemoFlight {
     credentials.refresh();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory();
+    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory(new HttpCredentialsAdapter(credentials));
     // [END auth]
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -116,11 +119,13 @@ public class DemoFlight {
       + "  \"reviewStatus\": \"underReview\""
       + "}", issuerId, classId);
 
-    HttpRequest classRequest = httpRequestFactory.buildPostRequest(
-        classUrl,
-        new JsonHttpContent(new GsonFactory(), classPayload));
-    classRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+    // Convert body to JSON
+    JsonParser classParser = GsonFactory.getDefaultInstance().createJsonParser(classPayload);
+    GenericJson classJson = classParser.parseAndClose(GenericJson.class);
+    HttpContent classBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), classJson);
+
+    // Create and send the request
+    HttpRequest classRequest = httpRequestFactory.buildPostRequest(classUrl, classBody);
     HttpResponse classResponse = classRequest.execute();
 
     System.out.println("class POST response:" + classResponse.parseAsString());
@@ -198,19 +203,20 @@ public class DemoFlight {
       + "  ]"
       + "}", objectId, issuerId, classId);
 
+    // Create and send the request
     HttpRequest objectRequest = httpRequestFactory.buildGetRequest(objectUrl);
-    objectRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse objectResponse = objectRequest.execute();
 
     if (objectResponse.getStatusCode() == 404) {
       // Object does not yet exist
       // Send POST request to create it
-      objectRequest = httpRequestFactory.buildPostRequest(
-          objectUrl,
-          new JsonHttpContent(new GsonFactory(), objectPayload));
-      objectRequest.setHeaders(new HttpHeaders()
-          .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+      // Convert body to JSON
+      JsonParser objectParser = GsonFactory.getDefaultInstance().createJsonParser(objectPayload);
+      GenericJson objectJson = objectParser.parseAndClose(GenericJson.class);
+      HttpContent objectBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), objectJson);
+
+      // Create and send the request
+      objectRequest = httpRequestFactory.buildPostRequest(objectUrl, objectBody);
       objectResponse = objectRequest.execute();
     }
 
@@ -274,9 +280,7 @@ public class DemoFlight {
 
     HttpRequest issuerRequest = httpRequestFactory.buildPostRequest(
         issuerUrl,
-        new JsonHttpContent(new GsonFactory(), issuerPayload));
-    issuerRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+        new JsonHttpContent(GsonFactory.getDefaultInstance(), issuerPayload));
     HttpResponse issuerResponse = issuerRequest.execute();
 
     System.out.println("issuer POST response: " + issuerResponse.parseAsString());
@@ -312,8 +316,6 @@ public class DemoFlight {
     HttpRequest permissionsRequest = httpRequestFactory.buildPutRequest(
         permissionsUrl,
         new JsonHttpContent(new GsonFactory(), permissionsPayload));
-    permissionsRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse permissionsResponse = permissionsRequest.execute();
 
     System.out.println("permissions PUT response: " + permissionsResponse.parseAsString());

--- a/java/src/main/java/DemoGeneric.java
+++ b/java/src/main/java/DemoGeneric.java
@@ -21,12 +21,15 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.*;
 import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.collect.Lists;
 
-import java.io.FileInputStream;
+import java.io.*;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 // [END imports]
@@ -83,7 +86,7 @@ public class DemoGeneric {
     credentials.refresh();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory();
+    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory(new HttpCredentialsAdapter(credentials));
     // [END auth]
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -98,11 +101,13 @@ public class DemoGeneric {
       + "  \"issuerName\": \"test issuer name\""
       + "}", issuerId, classId);
 
-    HttpRequest classRequest = httpRequestFactory.buildPostRequest(
-        classUrl,
-        new JsonHttpContent(new GsonFactory(), classPayload));
-    classRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+    // Convert body to JSON
+    JsonParser classParser = GsonFactory.getDefaultInstance().createJsonParser(classPayload);
+    GenericJson classJson = classParser.parseAndClose(GenericJson.class);
+    HttpContent classBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), classJson);
+
+    // Create and send the request
+    HttpRequest classRequest = httpRequestFactory.buildPostRequest(classUrl, classBody);
     HttpResponse classResponse = classRequest.execute();
 
     System.out.println("class POST response:" + classResponse.parseAsString());
@@ -189,19 +194,20 @@ public class DemoGeneric {
       + "  }"
       + "}", objectId, issuerId, classId);
 
+    // Create and send the request
     HttpRequest objectRequest = httpRequestFactory.buildGetRequest(objectUrl);
-    objectRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse objectResponse = objectRequest.execute();
 
     if (objectResponse.getStatusCode() == 404) {
       // Object does not yet exist
       // Send POST request to create it
-      objectRequest = httpRequestFactory.buildPostRequest(
-          objectUrl,
-          new JsonHttpContent(new GsonFactory(), objectPayload));
-      objectRequest.setHeaders(new HttpHeaders()
-          .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+      // Convert body to JSON
+      JsonParser objectParser = GsonFactory.getDefaultInstance().createJsonParser(objectPayload);
+      GenericJson objectJson = objectParser.parseAndClose(GenericJson.class);
+      HttpContent objectBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), objectJson);
+
+      // Create and send the request
+      objectRequest = httpRequestFactory.buildPostRequest(objectUrl, objectBody);
       objectResponse = objectRequest.execute();
     }
 
@@ -265,9 +271,7 @@ public class DemoGeneric {
 
     HttpRequest issuerRequest = httpRequestFactory.buildPostRequest(
         issuerUrl,
-        new JsonHttpContent(new GsonFactory(), issuerPayload));
-    issuerRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+        new JsonHttpContent(GsonFactory.getDefaultInstance(), issuerPayload));
     HttpResponse issuerResponse = issuerRequest.execute();
 
     System.out.println("issuer POST response: " + issuerResponse.parseAsString());
@@ -303,8 +307,6 @@ public class DemoGeneric {
     HttpRequest permissionsRequest = httpRequestFactory.buildPutRequest(
         permissionsUrl,
         new JsonHttpContent(new GsonFactory(), permissionsPayload));
-    permissionsRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse permissionsResponse = permissionsRequest.execute();
 
     System.out.println("permissions PUT response: " + permissionsResponse.parseAsString());

--- a/java/src/main/java/DemoGiftcard.java
+++ b/java/src/main/java/DemoGiftcard.java
@@ -21,12 +21,15 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.*;
 import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.collect.Lists;
 
-import java.io.FileInputStream;
+import java.io.*;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 // [END imports]
@@ -83,7 +86,7 @@ public class DemoGiftcard {
     credentials.refresh();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory();
+    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory(new HttpCredentialsAdapter(credentials));
     // [END auth]
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -101,11 +104,13 @@ public class DemoGiftcard {
       + "  \"reviewStatus\": \"underReview\""
       + "}", issuerId, classId);
 
-    HttpRequest classRequest = httpRequestFactory.buildPostRequest(
-        classUrl,
-        new JsonHttpContent(new GsonFactory(), classPayload));
-    classRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+    // Convert body to JSON
+    JsonParser classParser = GsonFactory.getDefaultInstance().createJsonParser(classPayload);
+    GenericJson classJson = classParser.parseAndClose(GenericJson.class);
+    HttpContent classBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), classJson);
+
+    // Create and send the request
+    HttpRequest classRequest = httpRequestFactory.buildPostRequest(classUrl, classBody);
     HttpResponse classResponse = classRequest.execute();
 
     System.out.println("class POST response:" + classResponse.parseAsString());
@@ -184,19 +189,20 @@ public class DemoGiftcard {
       + "  ]"
       + "}", objectId, issuerId, classId);
 
+    // Create and send the request
     HttpRequest objectRequest = httpRequestFactory.buildGetRequest(objectUrl);
-    objectRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse objectResponse = objectRequest.execute();
 
     if (objectResponse.getStatusCode() == 404) {
       // Object does not yet exist
       // Send POST request to create it
-      objectRequest = httpRequestFactory.buildPostRequest(
-          objectUrl,
-          new JsonHttpContent(new GsonFactory(), objectPayload));
-      objectRequest.setHeaders(new HttpHeaders()
-          .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+      // Convert body to JSON
+      JsonParser objectParser = GsonFactory.getDefaultInstance().createJsonParser(objectPayload);
+      GenericJson objectJson = objectParser.parseAndClose(GenericJson.class);
+      HttpContent objectBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), objectJson);
+
+      // Create and send the request
+      objectRequest = httpRequestFactory.buildPostRequest(objectUrl, objectBody);
       objectResponse = objectRequest.execute();
     }
 
@@ -260,9 +266,7 @@ public class DemoGiftcard {
 
     HttpRequest issuerRequest = httpRequestFactory.buildPostRequest(
         issuerUrl,
-        new JsonHttpContent(new GsonFactory(), issuerPayload));
-    issuerRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+        new JsonHttpContent(GsonFactory.getDefaultInstance(), issuerPayload));
     HttpResponse issuerResponse = issuerRequest.execute();
 
     System.out.println("issuer POST response: " + issuerResponse.parseAsString());
@@ -298,8 +302,6 @@ public class DemoGiftcard {
     HttpRequest permissionsRequest = httpRequestFactory.buildPutRequest(
         permissionsUrl,
         new JsonHttpContent(new GsonFactory(), permissionsPayload));
-    permissionsRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse permissionsResponse = permissionsRequest.execute();
 
     System.out.println("permissions PUT response: " + permissionsResponse.parseAsString());

--- a/java/src/main/java/DemoLoyalty.java
+++ b/java/src/main/java/DemoLoyalty.java
@@ -21,12 +21,15 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.*;
 import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.collect.Lists;
 
-import java.io.FileInputStream;
+import java.io.*;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 // [END imports]
@@ -83,7 +86,7 @@ public class DemoLoyalty {
     credentials.refresh();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory();
+    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory(new HttpCredentialsAdapter(credentials));
     // [END auth]
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -107,11 +110,13 @@ public class DemoLoyalty {
       + "  \"reviewStatus\": \"underReview\""
       + "}", issuerId, classId);
 
-    HttpRequest classRequest = httpRequestFactory.buildPostRequest(
-        classUrl,
-        new JsonHttpContent(new GsonFactory(), classPayload));
-    classRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+    // Convert body to JSON
+    JsonParser classParser = GsonFactory.getDefaultInstance().createJsonParser(classPayload);
+    GenericJson classJson = classParser.parseAndClose(GenericJson.class);
+    HttpContent classBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), classJson);
+
+    // Create and send the request
+    HttpRequest classRequest = httpRequestFactory.buildPostRequest(classUrl, classBody);
     HttpResponse classResponse = classRequest.execute();
 
     System.out.println("class POST response:" + classResponse.parseAsString());
@@ -189,19 +194,20 @@ public class DemoLoyalty {
       + "  ]"
       + "}", objectId, issuerId, classId);
 
+    // Create and send the request
     HttpRequest objectRequest = httpRequestFactory.buildGetRequest(objectUrl);
-    objectRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse objectResponse = objectRequest.execute();
 
     if (objectResponse.getStatusCode() == 404) {
       // Object does not yet exist
       // Send POST request to create it
-      objectRequest = httpRequestFactory.buildPostRequest(
-          objectUrl,
-          new JsonHttpContent(new GsonFactory(), objectPayload));
-      objectRequest.setHeaders(new HttpHeaders()
-          .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+      // Convert body to JSON
+      JsonParser objectParser = GsonFactory.getDefaultInstance().createJsonParser(objectPayload);
+      GenericJson objectJson = objectParser.parseAndClose(GenericJson.class);
+      HttpContent objectBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), objectJson);
+
+      // Create and send the request
+      objectRequest = httpRequestFactory.buildPostRequest(objectUrl, objectBody);
       objectResponse = objectRequest.execute();
     }
 
@@ -265,9 +271,7 @@ public class DemoLoyalty {
 
     HttpRequest issuerRequest = httpRequestFactory.buildPostRequest(
         issuerUrl,
-        new JsonHttpContent(new GsonFactory(), issuerPayload));
-    issuerRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+        new JsonHttpContent(GsonFactory.getDefaultInstance(), issuerPayload));
     HttpResponse issuerResponse = issuerRequest.execute();
 
     System.out.println("issuer POST response: " + issuerResponse.parseAsString());
@@ -303,8 +307,6 @@ public class DemoLoyalty {
     HttpRequest permissionsRequest = httpRequestFactory.buildPutRequest(
         permissionsUrl,
         new JsonHttpContent(new GsonFactory(), permissionsPayload));
-    permissionsRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse permissionsResponse = permissionsRequest.execute();
 
     System.out.println("permissions PUT response: " + permissionsResponse.parseAsString());

--- a/java/src/main/java/DemoTransit.java
+++ b/java/src/main/java/DemoTransit.java
@@ -21,12 +21,15 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.*;
 import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.collect.Lists;
 
-import java.io.FileInputStream;
+import java.io.*;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 // [END imports]
@@ -83,7 +86,7 @@ public class DemoTransit {
     credentials.refresh();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory();
+    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory(new HttpCredentialsAdapter(credentials));
     // [END auth]
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -108,11 +111,13 @@ public class DemoTransit {
       + "  }"
       + "}", issuerId, classId);
 
-    HttpRequest classRequest = httpRequestFactory.buildPostRequest(
-        classUrl,
-        new JsonHttpContent(new GsonFactory(), classPayload));
-    classRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+    // Convert body to JSON
+    JsonParser classParser = GsonFactory.getDefaultInstance().createJsonParser(classPayload);
+    GenericJson classJson = classParser.parseAndClose(GenericJson.class);
+    HttpContent classBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), classJson);
+
+    // Create and send the request
+    HttpRequest classRequest = httpRequestFactory.buildPostRequest(classUrl, classBody);
     HttpResponse classResponse = classRequest.execute();
 
     System.out.println("class POST response:" + classResponse.parseAsString());
@@ -234,19 +239,20 @@ public class DemoTransit {
       + "  ]"
       + "}", objectId, issuerId, classId);
 
+    // Create and send the request
     HttpRequest objectRequest = httpRequestFactory.buildGetRequest(objectUrl);
-    objectRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse objectResponse = objectRequest.execute();
 
     if (objectResponse.getStatusCode() == 404) {
       // Object does not yet exist
       // Send POST request to create it
-      objectRequest = httpRequestFactory.buildPostRequest(
-          objectUrl,
-          new JsonHttpContent(new GsonFactory(), objectPayload));
-      objectRequest.setHeaders(new HttpHeaders()
-          .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+      // Convert body to JSON
+      JsonParser objectParser = GsonFactory.getDefaultInstance().createJsonParser(objectPayload);
+      GenericJson objectJson = objectParser.parseAndClose(GenericJson.class);
+      HttpContent objectBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), objectJson);
+
+      // Create and send the request
+      objectRequest = httpRequestFactory.buildPostRequest(objectUrl, objectBody);
       objectResponse = objectRequest.execute();
     }
 
@@ -310,9 +316,7 @@ public class DemoTransit {
 
     HttpRequest issuerRequest = httpRequestFactory.buildPostRequest(
         issuerUrl,
-        new JsonHttpContent(new GsonFactory(), issuerPayload));
-    issuerRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+        new JsonHttpContent(GsonFactory.getDefaultInstance(), issuerPayload));
     HttpResponse issuerResponse = issuerRequest.execute();
 
     System.out.println("issuer POST response: " + issuerResponse.parseAsString());
@@ -348,8 +352,6 @@ public class DemoTransit {
     HttpRequest permissionsRequest = httpRequestFactory.buildPutRequest(
         permissionsUrl,
         new JsonHttpContent(new GsonFactory(), permissionsPayload));
-    permissionsRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse permissionsResponse = permissionsRequest.execute();
 
     System.out.println("permissions PUT response: " + permissionsResponse.parseAsString());

--- a/templates/template.java
+++ b/templates/template.java
@@ -21,12 +21,15 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.*;
 import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.collect.Lists;
 
-import java.io.FileInputStream;
+import java.io.*;
 import java.security.interfaces.RSAPrivateKey;
 import java.util.*;
 // [END imports]
@@ -83,7 +86,7 @@ public class Demo$object_type_titlecase {
     credentials.refresh();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory();
+    HttpRequestFactory httpRequestFactory = httpTransport.createRequestFactory(new HttpCredentialsAdapter(credentials));
     // [END auth]
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -94,11 +97,13 @@ public class Demo$object_type_titlecase {
     GenericUrl classUrl = new GenericUrl("https://walletobjects.googleapis.com/walletobjects/v1/$object_typeClass/");
     String classPayload = String.format($class_payload, issuerId, classId);
 
-    HttpRequest classRequest = httpRequestFactory.buildPostRequest(
-        classUrl,
-        new JsonHttpContent(new GsonFactory(), classPayload));
-    classRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+    // Convert body to JSON
+    JsonParser classParser = GsonFactory.getDefaultInstance().createJsonParser(classPayload);
+    GenericJson classJson = classParser.parseAndClose(GenericJson.class);
+    HttpContent classBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), classJson);
+
+    // Create and send the request
+    HttpRequest classRequest = httpRequestFactory.buildPostRequest(classUrl, classBody);
     HttpResponse classResponse = classRequest.execute();
 
     System.out.println("class POST response:" + classResponse.parseAsString());
@@ -113,19 +118,20 @@ public class Demo$object_type_titlecase {
         "https://walletobjects.googleapis.com/walletobjects/v1/$object_typeObject/" + objectId);
     String objectPayload = String.format($object_payload, objectId, issuerId, classId);
 
+    // Create and send the request
     HttpRequest objectRequest = httpRequestFactory.buildGetRequest(objectUrl);
-    objectRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse objectResponse = objectRequest.execute();
 
     if (objectResponse.getStatusCode() == 404) {
       // Object does not yet exist
       // Send POST request to create it
-      objectRequest = httpRequestFactory.buildPostRequest(
-          objectUrl,
-          new JsonHttpContent(new GsonFactory(), objectPayload));
-      objectRequest.setHeaders(new HttpHeaders()
-          .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+      // Convert body to JSON
+      JsonParser objectParser = GsonFactory.getDefaultInstance().createJsonParser(objectPayload);
+      GenericJson objectJson = objectParser.parseAndClose(GenericJson.class);
+      HttpContent objectBody = new JsonHttpContent(GsonFactory.getDefaultInstance(), objectJson);
+
+      // Create and send the request
+      objectRequest = httpRequestFactory.buildPostRequest(objectUrl, objectBody);
       objectResponse = objectRequest.execute();
     }
 
@@ -189,9 +195,7 @@ public class Demo$object_type_titlecase {
 
     HttpRequest issuerRequest = httpRequestFactory.buildPostRequest(
         issuerUrl,
-        new JsonHttpContent(new GsonFactory(), issuerPayload));
-    issuerRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
+        new JsonHttpContent(GsonFactory.getDefaultInstance(), issuerPayload));
     HttpResponse issuerResponse = issuerRequest.execute();
 
     System.out.println("issuer POST response: " + issuerResponse.parseAsString());
@@ -227,8 +231,6 @@ public class Demo$object_type_titlecase {
     HttpRequest permissionsRequest = httpRequestFactory.buildPutRequest(
         permissionsUrl,
         new JsonHttpContent(new GsonFactory(), permissionsPayload));
-    permissionsRequest.setHeaders(new HttpHeaders()
-        .setAuthorization("Bearer " + credentials.getAccessToken().getTokenValue()));
     HttpResponse permissionsResponse = permissionsRequest.execute();
 
     System.out.println("permissions PUT response: " + permissionsResponse.parseAsString());


### PR DESCRIPTION
* Resolves issue with JSON body not being interpreted when making PUT/POST calls
* Reduce code length/complexity by instantiating request credentials within the request factory instead of in each request

fixes #22 