### PR TITLE
added required trip type for transit passes

### DIFF
--- a/dotnet/DemoTransit.cs
+++ b/dotnet/DemoTransit.cs
@@ -263,6 +263,7 @@ class DemoTransit
           },
           PassengerType = "SINGLE_PASSENGER",
           PassengerNames = "Passenger names",
+          TripType = "ONE_WAY",
           TicketLeg = new TicketLeg
           {
             OriginStationCode = "LA",
@@ -473,6 +474,7 @@ class DemoTransit
       },
       PassengerType = "SINGLE_PASSENGER",
       PassengerNames = "Passenger names",
+      TripType = "ONE_WAY",
       TicketLeg = new TicketLeg
       {
         OriginStationCode = "LA",
@@ -727,6 +729,7 @@ class DemoTransit
         },
         PassengerType = "SINGLE_PASSENGER",
         PassengerNames = "Passenger names",
+        TripType = "ONE_WAY",
         TicketLeg = new TicketLeg
         {
           OriginStationCode = "LA",

--- a/http/demo_transit.http
+++ b/http/demo_transit.http
@@ -99,6 +99,7 @@ Connection: Keep-Alive
   ],
   "passengerType": "SINGLE_PASSENGER",
   "passengerNames": "Passenger names",
+  "tripType": "ONE_WAY",
   "ticketLeg": {
     "originStationCode": "LA",
     "originName": {
@@ -239,6 +240,7 @@ POST /walletobjects/v1/transitObject/
   ],
   "passengerType": "SINGLE_PASSENGER",
   "passengerNames": "Passenger names",
+  "tripType": "ONE_WAY",
   "ticketLeg": {
     "originStationCode": "LA",
     "originName": {
@@ -334,6 +336,7 @@ POST /walletobjects/v1/transitObject/
   ],
   "passengerType": "SINGLE_PASSENGER",
   "passengerNames": "Passenger names",
+  "tripType": "ONE_WAY",
   "ticketLeg": {
     "originStationCode": "LA",
     "originName": {
@@ -429,6 +432,7 @@ POST /walletobjects/v1/transitObject/
   ],
   "passengerType": "SINGLE_PASSENGER",
   "passengerNames": "Passenger names",
+  "tripType": "ONE_WAY",
   "ticketLeg": {
     "originStationCode": "LA",
     "originName": {

--- a/java/src/main/java/DemoTransit.java
+++ b/java/src/main/java/DemoTransit.java
@@ -226,6 +226,7 @@ public class DemoTransit {
                         .setLongitude(-122.09259560000001)))
             .setPassengerType("SINGLE_PASSENGER")
             .setPassengerNames("Passenger names")
+            .setTripType("ONE_WAY")
             .setTicketLeg(
                 new TicketLeg()
                     .setOriginStationCode("LA")
@@ -361,6 +362,7 @@ public class DemoTransit {
                         .setLongitude(-122.09259560000001)))
             .setPassengerType("SINGLE_PASSENGER")
             .setPassengerNames("Passenger names")
+            .setTripType("ONE_WAY")
             .setTicketLeg(
                 new TicketLeg()
                     .setOriginStationCode("LA")
@@ -384,7 +386,7 @@ public class DemoTransit {
                             .setDefaultValue(
                                 new TranslatedString()
                                     .setLanguage("en-US")
-                                    .setValue("Fare name"))));
+                                    .setValue("Fare name")))));
 
     // Create the JWT as a HashMap object
     HashMap<String, Object> claims = new HashMap<String, Object>();
@@ -563,6 +565,7 @@ public class DemoTransit {
                           .setLongitude(-122.09259560000001)))
               .setPassengerType("SINGLE_PASSENGER")
               .setPassengerNames("Passenger names")
+              .setTripType("ONE_WAY")
               .setTicketLeg(
                   new TicketLeg()
                       .setOriginStationCode("LA")

--- a/java/src/main/java/DemoTransit.java
+++ b/java/src/main/java/DemoTransit.java
@@ -386,7 +386,7 @@ public class DemoTransit {
                             .setDefaultValue(
                                 new TranslatedString()
                                     .setLanguage("en-US")
-                                    .setValue("Fare name")))));
+                                    .setValue("Fare name"))));
 
     // Create the JWT as a HashMap object
     HashMap<String, Object> claims = new HashMap<String, Object>();

--- a/nodejs/demo-transit.js
+++ b/nodejs/demo-transit.js
@@ -182,6 +182,7 @@ class DemoTransit {
       ],
       'passengerType': 'SINGLE_PASSENGER',
       'passengerNames': 'Passenger names',
+      'tripType': 'ONE_WAY',
       'ticketLeg': {
         'originStationCode': 'LA',
         'originName': {
@@ -347,6 +348,7 @@ class DemoTransit {
       ],
       'passengerType': 'SINGLE_PASSENGER',
       'passengerNames': 'Passenger names',
+      'tripType': 'ONE_WAY',
       'ticketLeg': {
         'originStationCode': 'LA',
         'originName': {
@@ -553,6 +555,7 @@ class DemoTransit {
         ],
         'passengerType': 'SINGLE_PASSENGER',
         'passengerNames': 'Passenger names',
+        'tripType': 'ONE_WAY',
         'ticketLeg': {
           'originStationCode': 'LA',
           'originName': {

--- a/php/demo_transit.php
+++ b/php/demo_transit.php
@@ -208,6 +208,7 @@ class DemoTransit
       ],
       'passengerType' => 'SINGLE_PASSENGER',
       'passengerNames' => 'Passenger names',
+      'tripType' => 'ONE_WAY',
       'ticketLeg' => new Google_Service_Walletobjects_TicketLeg([
         'originStationCode' => 'LA',
         'originName' => new Google_Service_Walletobjects_LocalizedString([
@@ -360,6 +361,7 @@ class DemoTransit
       ],
       'passengerType' => 'SINGLE_PASSENGER',
       'passengerNames' => 'Passenger names',
+      'tripType' => 'ONE_WAY',
       'ticketLeg' => new Google_Service_Walletobjects_TicketLeg([
         'originStationCode' => 'LA',
         'originName' => new Google_Service_Walletobjects_LocalizedString([
@@ -564,6 +566,7 @@ class DemoTransit
         ],
         'passengerType' => 'SINGLE_PASSENGER',
         'passengerNames' => 'Passenger names',
+        'tripType' => 'ONE_WAY',
         'ticketLeg' => new Google_Service_Walletobjects_TicketLeg([
           'originStationCode' => 'LA',
           'originName' => new Google_Service_Walletobjects_LocalizedString([

--- a/python/demo_transit.py
+++ b/python/demo_transit.py
@@ -189,6 +189,7 @@ class DemoTransit:
             },],
             'passengerType': 'SINGLE_PASSENGER',
             'passengerNames': 'Passenger names',
+            'tripType': 'ONE_WAY',
             'ticketLeg': {
                 'originStationCode': 'LA',
                 'originName': {
@@ -341,6 +342,7 @@ class DemoTransit:
             },],
             'passengerType': 'SINGLE_PASSENGER',
             'passengerNames': 'Passenger names',
+            'tripType': 'ONE_WAY',
             'ticketLeg': {
                 'originStationCode': 'LA',
                 'originName': {
@@ -545,6 +547,7 @@ class DemoTransit:
                 },],
                 'passengerType': 'SINGLE_PASSENGER',
                 'passengerNames': 'Passenger names',
+                'tripType': 'ONE_WAY',
                 'ticketLeg': {
                     'originStationCode': 'LA',
                     'originName': {


### PR DESCRIPTION
TripType is mandatory: [trip-type-for-transit-passes](https://developers.google.com/wallet/tickets/transit-passes/qr-code/rest/v1/transitobject#TripType)